### PR TITLE
Refresh bug

### DIFF
--- a/frontend/src/client/realTimeEditor.jsx
+++ b/frontend/src/client/realTimeEditor.jsx
@@ -33,6 +33,10 @@ const RealTimeEditor = () => {
             editor.setValue(code)
         })
 
+        client.collabSocket.on('CODE_INIT', (code) => {
+            editor.setValue(code)
+        })
+
     }, [])
     return (
         <>


### PR DESCRIPTION
Fix a bug where if the user is in a collab room and he refreshes, the text editor will be cleared.
This is due to the sockets recognizing a refreshed page as a 'new input' and since the text editor of the refreshed page is blank, it would update both users to a blank slate. 
It is fixed by storing the user inputs in the server side. This is cleared when the user exits the collab service normally.